### PR TITLE
Allow karma version 2.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "grunt": ">=0.4.x || ^1.0.0",
-    "karma": "^0.13.0 || ^1.0.0"
+    "karma": "^0.13.0 || ^1.0.0 || ^2.0.0"
   },
   "contributors": [
     "Dave Geddes <davidcgeddes@gmail.com>",


### PR DESCRIPTION
Karma v2 is working just fine with our project, so we can update the allowed versions in peerDependencies to prevent warnings like this:

```
npm WARN grunt-karma@2.0.0 requires a peer of karma@^0.13.0 || ^1.0.0 but none is installed. You must install peer dependencies yourself.
```